### PR TITLE
[FE] ✨ 프로필 수정 성공, 실패에 따른 분기 처리

### DIFF
--- a/client/app/main/_components/ProfileFrame.tsx
+++ b/client/app/main/_components/ProfileFrame.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 
 import useUserDetailQuery from '../hooks/query/useUserDetailQuery';
 
+import { USER_DEFAULT_PROFILE_IMAGE } from '../constants/data';
+
 export default function ProfileFrame() {
   const { userDetail } = useUserDetailQuery();
 
@@ -39,5 +41,3 @@ export default function ProfileFrame() {
     </section>
   );
 }
-
-const USER_DEFAULT_PROFILE_IMAGE = '/assets/image/default_profile_image.svg';

--- a/client/app/main/_components/ProfileImageEditor.tsx
+++ b/client/app/main/_components/ProfileImageEditor.tsx
@@ -4,13 +4,15 @@ import Image from 'next/image';
 
 import useUserDetailQuery from '../hooks/query/useUserDetailQuery';
 
+import { USER_DEFAULT_PROFILE_IMAGE } from '../constants/data';
+
 export default function ProfileImageEditor() {
   const { userDetail } = useUserDetailQuery();
 
   return (
     <div className="flex flex-col justify-center items-center mt-4">
       <Image
-        src={userDetail.profileImage}
+        src={userDetail?.profileImage || USER_DEFAULT_PROFILE_IMAGE}
         alt="profile image"
         width={80}
         height={80}
@@ -25,7 +27,9 @@ export default function ProfileImageEditor() {
         className="relative left-7 bottom-7 rounded-full"
       />
 
-      <h2 className="text-2xl font-semibold -mt-5">{userDetail.name}</h2>
+      <h2 className="text-2xl font-semibold -mt-5">
+        {userDetail?.name || 'Unknown'}
+      </h2>
     </div>
   );
 }

--- a/client/app/main/constants/data.ts
+++ b/client/app/main/constants/data.ts
@@ -29,3 +29,6 @@ export const PROFILE_SETTING = {
     image: '/assets/icon/resign.svg',
   },
 };
+
+export const USER_DEFAULT_PROFILE_IMAGE =
+  '/assets/image/default_profile_image.svg';

--- a/client/app/main/hooks/mutation/useUpdateUserDetailMutation.ts
+++ b/client/app/main/hooks/mutation/useUpdateUserDetailMutation.ts
@@ -2,6 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { patchUserDetail } from '../../_api/user';
 
+import useNavigationStore from 'store/navigationStore';
+
 import { ChangeEmailAndPassword } from '../../types/data';
 
 const useUpdateUserDetailMutation = ({
@@ -10,6 +12,8 @@ const useUpdateUserDetailMutation = ({
   changedPassword,
 }: ChangeEmailAndPassword) => {
   const queryClient = useQueryClient();
+
+  const { setSettingType } = useNavigationStore();
 
   const { mutate } = useMutation({
     mutationFn: () =>
@@ -20,6 +24,11 @@ const useUpdateUserDetailMutation = ({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['userDetail'] });
+
+      return alert('diubah.'), setSettingType('');
+    },
+    onError: () => {
+      return alert('Email atau kata sandi tidak cocok.');
     },
   });
 


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [ ] ADD : 에셋 파일 추가
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [x] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CONF: 빌드, 환경 설정
- [ ] CHORE: 기타 작업

## Abstracts
- 프로필 수정 성공, 실패에 따른 분기 처리를 했습니다.
- 프로필 이미지, 이름을 못 불러올 시에 기본 설정으로 처리했습니다.

## Description
* 실패
<img width="1277" alt="스크린샷 2024-05-12 오후 3 19 27" src="https://github.com/shimdokite/wisecrypto/assets/126948653/079746ab-44f7-48f5-8a33-72493e0b4ce9">

* 성공
<img width="1277" alt="스크린샷 2024-05-12 오후 3 19 42" src="https://github.com/shimdokite/wisecrypto/assets/126948653/2211c12a-4367-4da3-801e-06c4218a0560">


## Discussion
- 추가적인 개발로는 프로필 이미지 변경이 필요할 것 같습니다.
- 이메일, 비밀번호를 기존과 같아도 상관없는지 정책을 만들고 추가 작업이 필요할 것 같습니다.
